### PR TITLE
Use proper capitalization for Name tag

### DIFF
--- a/asg.tf
+++ b/asg.tf
@@ -16,7 +16,7 @@ resource "aws_autoscaling_group" "bastion" {
   ]
   tags = [
     {
-      "key" = "name"
+      "key" = "Name"
       "value" = "${var.name}"
       "propagate_at_launch" = "true"
     },


### PR DESCRIPTION
If 'Name' is lowercased, it won't show it by default in the 'Name' column in the web interface.