### PR TITLE
OPS-1063 fix regex for terraform 0.11.11

### DIFF
--- a/s3.tf
+++ b/s3.tf
@@ -25,8 +25,8 @@ resource "aws_s3_bucket_object" "ssh_public_keys" {
         "=",
         ""
       ),
-    "/\/\//",
-    "\//",
+    "/\\/\\//",
+    "\\//",
     )
   }"
   content = "${file("${var.authorized_keys_directory}/${element(var.authorized_key_names,count.index)}.pub")}"


### PR DESCRIPTION
[OPS-1063](https://bitgoinc.atlassian.net/browse/OPS-1063)
During testing, this issue did not show up. It appears as if we were
testing using an older version of terraform. In terraform 0.11.11 an
error appears when running `terraform plan`. This commit fixes this
newly introduced bug