### PR TITLE
Update for latest ignition provider

### DIFF
--- a/ec2.tf
+++ b/ec2.tf
@@ -74,16 +74,16 @@ data "ignition_systemd_unit" "mask_containerd" {
 
 data "ignition_config" "bastion" {
   systemd = [
-    "${data.ignition_systemd_unit.sshd_port.id}",
-    "${data.ignition_systemd_unit.mask_containerd.id}",
-    "${data.ignition_systemd_unit.mask_docker.id}",
+    "${data.ignition_systemd_unit.sshd_port.rendered}",
+    "${data.ignition_systemd_unit.mask_containerd.rendered}",
+    "${data.ignition_systemd_unit.mask_docker.rendered}",
   ]
   users = [
-    "${data.ignition_user.tunnel.id}",
+    "${data.ignition_user.tunnel.rendered}",
   ]
   files = [
-    "${data.ignition_file.sshd_config.id}",
-    "${data.ignition_file.sshd_authorized_keys.id}",
+    "${data.ignition_file.sshd_config.rendered}",
+    "${data.ignition_file.sshd_authorized_keys.rendered}",
   ]
 }
 


### PR DESCRIPTION
If you attempt to use this module with the latest ignition provider, you'll run into the following error:

```
Error: Error refreshing state: 1 error occurred:
	* module.bastion-usw2.data.ignition_config.bastion: 1 error occurred:
	* module.bastion-usw2.data.ignition_config.bastion: data.ignition_config.bastion: No valid JSON found, make sure you're using .rendered and not .id: invalid character 'f' after top-level value
```

This is resolved by updating `data.ignition_config.bastion` in the module to use `.rendered` instead of `.id` for each component data element.

Jira Ticket: [DO-933](https://bitgoinc.atlassian.net/browse/DO-933)