### PR TITLE
Use filesha256 for setting ssh-key s3 object

### DIFF
--- a/ec2.tf
+++ b/ec2.tf
@@ -47,7 +47,7 @@ data "ignition_file" "sshd_authorized_keys" {
   content {
     content = <<EOF
 #!/bin/bash
-curl -sf "${aws_s3_bucket.ssh_public_keys.website_endpoint}/$${2/SHA256:/}"
+curl -sf "${aws_s3_bucket.ssh_public_keys.website_endpoint}/${aws_s3_bucket_object.ssh_public_keys.id}"
 EOF
 
   }

--- a/s3.tf
+++ b/s3.tf
@@ -8,26 +8,8 @@ resource "aws_s3_bucket" "ssh_public_keys" {
 
 resource "aws_s3_bucket_object" "ssh_public_keys" {
   bucket = aws_s3_bucket.ssh_public_keys.bucket
-  key = replace(
-    replace(
-      base64sha256(
-        base64decode(
-          element(
-            split(
-              " ",
-              file(
-                "${var.authorized_keys_directory}/${element(var.authorized_key_names, count.index)}.pub",
-              ),
-            ),
-            "1",
-          ),
-        ),
-      ),
-      "=",
-      "",
-    ),
-    "/\\/\\//",
-    "\\//",
+  key    = filesha256(
+    "${var.authorized_keys_directory}/${element(var.authorized_key_names, count.index)}.pub"
   )
 
   content = file(


### PR DESCRIPTION
Newer versions of terraform have an issue with base64 decoding and UTF-8 integrity: https://github.com/hashicorp/terraform/issues/25777

Replacing the s3 object key with concatenated `file256sha` string.