### PR TITLE
Use a single authorized_keys file in s3

### DIFF
--- a/ec2.tf
+++ b/ec2.tf
@@ -32,7 +32,7 @@ AllowUsers ${join(" ", var.allowed_users)}
 AuthenticationMethods publickey
 PermitRootLogin no
 AuthorizedKeysCommandUser nobody
-AuthorizedKeysCommand /etc/ssh/authorized_keys.sh %u %f
+AuthorizedKeysCommand /etc/ssh/authorized_keys.sh
 EOF
 
   }
@@ -47,7 +47,7 @@ data "ignition_file" "sshd_authorized_keys" {
   content {
     content = <<EOF
 #!/bin/bash
-curl -sf "${aws_s3_bucket.ssh_public_keys.website_endpoint}/$${2/SHA256:/}"
+curl -sf "${aws_s3_bucket.ssh_public_keys.website_endpoint}/${aws_s3_bucket_object.ssh_public_keys.id}"
 EOF
 
   }

--- a/s3.tf
+++ b/s3.tf
@@ -8,32 +8,15 @@ resource "aws_s3_bucket" "ssh_public_keys" {
 
 resource "aws_s3_bucket_object" "ssh_public_keys" {
   bucket = aws_s3_bucket.ssh_public_keys.bucket
-  key = replace(
-    replace(
-      base64sha256(
-        base64decode(
-          element(
-            split(
-              " ",
-              file(
-                "${var.authorized_keys_directory}/${element(var.authorized_key_names, count.index)}.pub",
-              ),
-            ),
-            "1",
-          ),
-        ),
-      ),
-      "=",
-      "",
-    ),
-    "/\\/\\//",
-    "\\//",
-  )
+  key    = "authorized_keys"
 
-  content = file(
-    "${var.authorized_keys_directory}/${element(var.authorized_key_names, count.index)}.pub",
+  content = join(
+    "",
+    [
+      for name in var.authorized_key_names:
+      "# ${name}\n${file("${var.authorized_keys_directory}/${name}.pub")}"
+    ]
   )
-  count      = length(var.authorized_key_names)
   depends_on = [aws_s3_bucket.ssh_public_keys]
   acl        = "public-read"
 }


### PR DESCRIPTION
Instead of uploading multiple key files, we can use terraform 0.12's `for` to concatenate all the desired key files.