### PR TITLE
Use explicit name for authorized_keys id

### DIFF
--- a/ec2.tf
+++ b/ec2.tf
@@ -47,7 +47,7 @@ data "ignition_file" "sshd_authorized_keys" {
   content {
     content = <<EOF
 #!/bin/bash
-curl -sf "${aws_s3_bucket.ssh_public_keys.website_endpoint}/${aws_s3_bucket_object.ssh_public_keys.id}"
+curl -sf "${aws_s3_bucket.ssh_public_keys.website_endpoint}/authorized_keys"
 EOF
 
   }

--- a/s3.tf
+++ b/s3.tf
@@ -14,7 +14,7 @@ resource "aws_s3_bucket_object" "ssh_public_keys" {
     "",
     [
       for name in var.authorized_key_names:
-      "# ${name}\n${file("${var.authorized_keys_directory}/${name}.pub")}"
+      "# ${name}\n${file("${var.authorized_keys_directory}/${name}.pub")}\n"
     ]
   )
   depends_on = [aws_s3_bucket.ssh_public_keys]


### PR DESCRIPTION
- Using explicit name for s3 object as terraform complains when using the `id`
- Add newline after each key for safety