### PR TITLE
terraform 0.13 support

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -1,3 +1,11 @@
 terraform {
   required_version = ">= 0.12"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    ignition = {
+      source = "terraform-providers/ignition"
+    }
+  }
 }


### PR DESCRIPTION
Terraform 0.13 requires that providers have explicit source locations.
https://www.terraform.io/upgrade-guides/0-13.html#explicit-provider-source-locations

I've kept it in the terraform 0.12 compatible format, so upgrades
shouldn't be forced on users.
https://www.terraform.io/docs/configuration/provider-requirements.html#v012-compatible-provider-requirements