### PR TITLE
Add ability to specify additional security groups for the bastion

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Deploy a minimal, auto-healing, and immutable SSH Bastion host on AWS.
 
   * ```name``` - name of the bastion; suggest 'bastion-<unique_identifier>'
   * ```instance_type``` - instance type of bastion
+  * ```additional_security_groups``` - security groups to add to the bastion instance, e.g. if you have other security groups with "source_security_group" rules that you'd like the bastion to be covered by
   * ```authorized_keys_directory``` - folder of keys to allow for ssh
   * ```authorized_key_names``` - names of public keys to allow for ssh
   * ```allowed_cidrs``` - CIDRs that are allowed to reach instance via SSH

--- a/ec2.tf
+++ b/ec2.tf
@@ -111,9 +111,10 @@ resource "aws_launch_template" "bastion" {
   }
 
   network_interfaces {
-    security_groups = [
-      aws_security_group.bastion.id,
-    ]
+    security_groups = concat(
+      [aws_security_group.bastion.id],
+      var.additional_security_groups,
+    )
 
     associate_public_ip_address = var.associate_public_ip_address
   }

--- a/variables.tf
+++ b/variables.tf
@@ -26,6 +26,12 @@ variable "iam_instance_profile" {
   default = ""
 }
 
+variable "additional_security_groups" {
+  description = "A list of additional security groups to assign to the bastion instance"
+  type        = list(string)
+  default     = []
+}
+
 variable "allowed_cidrs" {
   type = list(string)
   


### PR DESCRIPTION
e.g. if you have other security groups with [`source_security_group` rules](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule#source_security_group_id) that you'd like the bastion to be covered by