### PR TITLE
Updates for AWS provider 4.x

### DIFF
--- a/asg.tf
+++ b/asg.tf
@@ -20,13 +20,11 @@ resource "aws_autoscaling_group" "bastion" {
     "GroupTotalInstances",
   ]
 
-  tags = [
-    {
-      "key"                 = "Name"
-      "value"               = var.name
-      "propagate_at_launch" = "true"
-    },
-  ]
+  tag {
+    key                 = "Name"
+    value               = var.name
+    propagate_at_launch = "true"
+  }
 
   instance_refresh {
     strategy = "Rolling"

--- a/s3.tf
+++ b/s3.tf
@@ -1,22 +1,30 @@
 resource "aws_s3_bucket" "ssh_public_keys" {
   bucket_prefix = "ssh-keys-"
-  acl           = "public-read"
-  website {
-    index_document = "index.html"
+}
+
+resource "aws_s3_bucket_acl" "ssh_public_keys" {
+  bucket = aws_s3_bucket.ssh_public_keys.id
+  acl    = "public-read"
+}
+
+resource "aws_s3_bucket_website_configuration" "ssh_public_keys" {
+  bucket = aws_s3_bucket.ssh_public_keys.bucket
+
+  index_document {
+    suffix = "index.html"
   }
 }
 
-resource "aws_s3_bucket_object" "ssh_public_keys" {
+resource "aws_s3_object" "ssh_public_keys" {
   bucket = aws_s3_bucket.ssh_public_keys.bucket
   key    = "authorized_keys"
 
   content = join(
     "",
     [
-      for name in var.authorized_key_names:
+      for name in var.authorized_key_names :
       "# ${name}\n${file("${var.authorized_keys_directory}/${name}.pub")}\n"
     ]
   )
-  depends_on = [aws_s3_bucket.ssh_public_keys]
-  acl        = "public-read"
+  acl = "public-read"
 }

--- a/sg.tf
+++ b/sg.tf
@@ -17,7 +17,7 @@ data "aws_iam_policy_document" "s3_bucket_access" {
 
     actions = ["s3:GetObject"]
 
-    resources = ["${aws_s3_bucket.ssh_public_keys.arn}/${aws_s3_bucket_object.ssh_public_keys.key}"]
+    resources = ["${aws_s3_bucket.ssh_public_keys.arn}/${aws_s3_object.ssh_public_keys.key}"]
   }
 }
 

--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,8 @@ terraform {
   required_version = ">= 0.12"
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
+      version = ">= 4.0.0"
     }
     ignition = {
       source = "terraform-providers/ignition"


### PR DESCRIPTION
There were several breaking changes in the AWS provider.
Release announcement: https://github.com/hashicorp/terraform-provider-aws/releases/tag/v4.0.0
Migration Guide: https://github.com/hashicorp/terraform-provider-aws/blob/ac0a1be170c4939b9af5239bd93eef02688309e5/website/docs/guides/version-4-upgrade.html.md