### PR TITLE
Require IMDSv2 for bastion instances

### DIFF
--- a/ec2.tf
+++ b/ec2.tf
@@ -33,6 +33,13 @@ resource "aws_launch_template" "bastion" {
     enabled = true
   }
 
+  metadata_options {
+    http_endpoint               = "enabled"
+    http_tokens                 = "required"
+    http_put_response_hop_limit = 1
+    instance_metadata_tags      = "disabled"
+  }
+
   network_interfaces {
     security_groups = concat(
       [aws_security_group.bastion.id],


### PR DESCRIPTION
## Summary
Configures launch template to require IMDSv2, following AWS security best practices to prevent SSRF attacks.

## Changes
- Added `metadata_options` block to launch template
- Set `http_tokens = "required"` to enforce IMDSv2
- Set `http_put_response_hop_limit = 1` for security
- Disabled instance metadata tags

## Reference
https://aws.amazon.com/blogs/security/get-the-full-benefits-of-imdsv2-and-disable-imdsv1-across-your-aws-infrastructure/